### PR TITLE
Add check for xml file type

### DIFF
--- a/src/pptx/package.rs
+++ b/src/pptx/package.rs
@@ -54,6 +54,10 @@ impl Package {
 
             match PathBuf::from(zip_file.name()) {
                 file_path if file_path.starts_with("ppt/theme") => {
+                    if file_path.extension().unwrap_or_default() != "xml" {
+                        continue;
+                    }
+                    
                     info!("parsing theme file: {}", zip_file.name());
                     theme_map.insert(file_path, Box::new(OfficeStyleSheet::from_zip_file(&mut zip_file)?));
                 }


### PR DESCRIPTION
I was testing your package and it errored out because it tried to parse a directory as an xml file. Seems like you forgot to put a file type check in just one place.

```log
[2025-06-13T16:17:00Z INFO  oox::pptx::package] parsing slide file: ppt/slides/slide6.xml
[2025-06-13T16:17:00Z INFO  oox::pptx::package] parsing slide file: ppt/slides/slide7.xml
[2025-06-13T16:17:00Z INFO  oox::pptx::package] parsing slide file: ppt/slides/slide8.xml
[2025-06-13T16:17:00Z INFO  oox::pptx::package] parsing slide file: ppt/slides/slide9.xml
[2025-06-13T16:17:00Z INFO  oox::pptx::package] parsing theme file: ppt/theme/

thread 'main' panicked at src/main.rs:10:74:
called `Result::unwrap()` on an `Err` value: InvalidXmlError
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

With my patch works as intended.
