### PR TITLE
dependecy cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,24 +9,19 @@ license = "MIT"
 repository = "https://github.com/dam4rus/oox-rs.git"
 homepage = "https://github.com/dam4rus/oox-rs"
 readme = "README.md"
-exclude = [
-    "tests/sample.pptx",
-    "tests/sample.docx",
-    "tests/presentation.xml",
-]
+exclude = ["tests/sample.pptx", "tests/sample.docx", "tests/presentation.xml"]
 
 [dependencies]
-quick-xml = "0.39.2"
-zip = "8.2.0"
-log = "0.4.29"
-strum = "0.28.0"
-strum_macros = "0.28.0"
-regex = "1.12.3"
-
-[dev-dependencies]
-simple_logger = "1.4.0"
+quick-xml = "0.40.1"
+zip = { version = "8.6.0", default-features = false, features = [
+    "deflate-flate2",
+] }
+flate2 = { version = "1.1.9" } # need to be added for the deflate-flate2 feature
+regex = { version = "1.12.3", default-features = false, features = ["std"] }
+strum = { version = "0.28", features = ["derive"] }
+log = "0.4.32"
 
 [features]
 docx = []
 pptx = []
-all = [ "docx", "pptx" ]
+all = ["docx", "pptx"]

--- a/src/docx/wml/document.rs
+++ b/src/docx/wml/document.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 use log::info;
 use std::str::FromStr;
+use strum::EnumString;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/src/docx/wml/drawing.rs
+++ b/src/docx/wml/drawing.rs
@@ -18,6 +18,7 @@ use crate::{
     xml::{XmlNode, parse_xml_bool},
     xsdtypes::XsdChoice,
 };
+use strum::EnumString;
 
 type Result<T> = ::std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/src/docx/wml/footnotes.rs
+++ b/src/docx/wml/footnotes.rs
@@ -4,6 +4,7 @@ use crate::{
     xml::XmlNode,
     xsdtypes::XsdChoice,
 };
+use strum::EnumString;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/src/docx/wml/numbering.rs
+++ b/src/docx/wml/numbering.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use log::info;
 use std::any::Any;
+use strum::EnumString;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/src/docx/wml/settings.rs
+++ b/src/docx/wml/settings.rs
@@ -13,6 +13,7 @@ use crate::{
     xml::{XmlNode, parse_xml_bool},
 };
 use log::info;
+use strum::EnumString;
 
 pub type Base64Binary = String;
 pub type DocType = String;

--- a/src/docx/wml/styles.rs
+++ b/src/docx/wml/styles.rs
@@ -10,6 +10,7 @@ use crate::{
     xml::{XmlNode, parse_xml_bool},
 };
 use log::info;
+use strum::EnumString;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/src/docx/wml/table.rs
+++ b/src/docx/wml/table.rs
@@ -14,6 +14,7 @@ use crate::{
     xsdtypes::{XsdChoice, XsdType},
 };
 use log::info;
+use strum::EnumString;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,5 +11,3 @@ pub mod xml;
 pub mod xsdtypes;
 
 extern crate strum;
-#[macro_use]
-extern crate strum_macros;

--- a/src/pptx/pml/animation.rs
+++ b/src/pptx/pml/animation.rs
@@ -16,6 +16,7 @@ use crate::{
     xsdtypes::{XsdChoice, XsdType},
 };
 use std::{error::Error, str::FromStr};
+use strum::EnumString;
 
 pub type Result<T> = ::std::result::Result<T, Box<dyn Error>>;
 

--- a/src/pptx/pml/presentation.rs
+++ b/src/pptx/pml/presentation.rs
@@ -16,6 +16,7 @@ use std::{
     io::{Read, Seek},
     str::FromStr,
 };
+use strum::EnumString;
 
 pub type Result<T> = ::std::result::Result<T, Box<dyn Error>>;
 

--- a/src/pptx/pml/slides.rs
+++ b/src/pptx/pml/slides.rs
@@ -22,6 +22,7 @@ use crate::{
     xsdtypes::{XsdChoice, XsdType},
 };
 use std::{error::Error, io::Read, str::FromStr};
+use strum::EnumString;
 use zip::read::ZipFile;
 
 use super::{

--- a/src/shared/drawingml/simpletypes.rs
+++ b/src/shared/drawingml/simpletypes.rs
@@ -1,5 +1,6 @@
 use crate::error::{AdjustParseError, ParseHexColorRGBError, StringLengthMismatch};
 use std::str::FromStr;
+use strum::EnumString;
 
 /// This simple type specifies that its values shall be a 128-bit globally unique identifier (GUID) value.
 ///

--- a/src/shared/sharedtypes.rs
+++ b/src/shared/sharedtypes.rs
@@ -1,6 +1,7 @@
 use crate::error::PatternRestrictionError;
 use regex::Regex;
 use std::{marker::PhantomData, str::FromStr};
+use strum::EnumString;
 
 pub type OnOff = bool;
 pub type Lang = String;


### PR DESCRIPTION
Before:
oox v0.1.0
├── log v0.4.32
├── quick-xml v0.39.4
│   └── memchr v2.8.1
├── regex v1.12.3
│   ├── aho-corasick v1.1.4
│   │   └── memchr v2.8.1
│   ├── memchr v2.8.1
│   ├── regex-automata v0.4.14
│   │   ├── aho-corasick v1.1.4 (*)
│   │   ├── memchr v2.8.1
│   │   └── regex-syntax v0.8.10
│   └── regex-syntax v0.8.10
├── strum v0.28.0
├── strum_macros v0.28.0 (proc-macro)
│   ├── heck v0.5.0
│   ├── proc-macro2 v1.0.106
│   │   └── unicode-ident v1.0.24
│   ├── quote v1.0.45
│   │   └── proc-macro2 v1.0.106 (*)
│   └── syn v2.0.117
│       ├── proc-macro2 v1.0.106 (*)
│       ├── quote v1.0.45 (*)
│       └── unicode-ident v1.0.24
└── zip v8.6.0
    ├── aes v0.9.1
    │   ├── cipher v0.5.2
    │   │   ├── crypto-common v0.2.2
    │   │   │   └── hybrid-array v0.4.12
    │   │   │       └── typenum v1.20.1
    │   │   └── inout v0.2.2
    │   │       └── hybrid-array v0.4.12 (*)
    │   ├── cpubits v0.1.1
    │   └── cpufeatures v0.3.0
    ├── bzip2 v0.6.1
    │   └── libbz2-rs-sys v0.2.5
    ├── constant_time_eq v0.4.2
    ├── crc32fast v1.5.0
    │   └── cfg-if v1.0.4
    ├── deflate64 v0.1.12
    ├── flate2 v1.1.9
    │   └── zlib-rs v0.6.3
    ├── getrandom v0.4.2
    │   ├── cfg-if v1.0.4
    │   └── libc v0.2.186
    ├── hmac v0.13.0
    │   └── digest v0.11.3
    │       ├── block-buffer v0.12.0
    │       │   ├── hybrid-array v0.4.12 (*)
    │       │   └── zeroize v1.8.2
    │       ├── const-oid v0.10.2
    │       ├── crypto-common v0.2.2 (*)
    │       ├── ctutils v0.4.2
    │       │   └── cmov v0.5.4
    │       └── zeroize v1.8.2
    ├── indexmap v2.14.0
    │   ├── equivalent v1.0.2
    │   └── hashbrown v0.17.1
    ├── lzma-rust2 v0.16.4
    │   └── sha2 v0.11.0
    │       ├── cfg-if v1.0.4
    │       ├── cpufeatures v0.3.0
    │       └── digest v0.11.3 (*)
    ├── memchr v2.8.1
    ├── pbkdf2 v0.13.0
    │   ├── digest v0.11.3 (*)
    │   └── hmac v0.13.0 (*)
    ├── ppmd-rust v1.4.0
    ├── sha1 v0.11.0
    │   ├── cfg-if v1.0.4
    │   ├── cpufeatures v0.3.0
    │   └── digest v0.11.3 (*)
    ├── time v0.3.47
    │   ├── deranged v0.5.8
    │   │   └── powerfmt v0.2.0
    │   ├── itoa v1.0.18
    │   ├── libc v0.2.186
    │   ├── num-conv v0.2.2
    │   ├── num_threads v0.1.7
    │   ├── powerfmt v0.2.0
    │   ├── time-core v0.1.8
    │   └── time-macros v0.2.27 (proc-macro)
    │       ├── num-conv v0.2.2
    │       └── time-core v0.1.8
    ├── typed-path v0.12.3
    ├── zeroize v1.8.2
    ├── zopfli v0.8.3
    │   ├── bumpalo v3.20.3
    │   ├── crc32fast v1.5.0 (*)
    │   ├── log v0.4.32
    │   └── simd-adler32 v0.3.9
    └── zstd v0.13.3
        └── zstd-safe v7.2.4
            └── zstd-sys v2.0.16+zstd.1.5.7
                [build-dependencies]
                ├── cc v1.2.63
                │   ├── find-msvc-tools v0.1.9
                │   ├── jobserver v0.1.34
                │   │   └── libc v0.2.186
                │   ├── libc v0.2.186
                │   └── shlex v2.0.1
                └── pkg-config v0.3.33
[dev-dependencies]
└── simple_logger v1.16.0
    ├── colored v1.9.4
    │   ├── is-terminal v0.4.17
    │   │   └── libc v0.2.186
    │   └── lazy_static v1.5.0
    ├── log v0.4.32
    └── time v0.3.47 (*)


After:
oox v0.1.0
├── flate2 v1.1.9
│   ├── crc32fast v1.5.0
│   │   └── cfg-if v1.0.4
│   └── miniz_oxide v0.8.9
│       ├── adler2 v2.0.1
│       └── simd-adler32 v0.3.9
├── log v0.4.32
├── quick-xml v0.40.1
│   └── memchr v2.8.1
├── regex v1.12.3
│   ├── regex-automata v0.4.14
│   │   └── regex-syntax v0.8.10
│   └── regex-syntax v0.8.10
├── strum v0.28.0
│   └── strum_macros v0.28.0 (proc-macro)
│       ├── heck v0.5.0
│       ├── proc-macro2 v1.0.106
│       │   └── unicode-ident v1.0.24
│       ├── quote v1.0.45
│       │   └── proc-macro2 v1.0.106 (*)
│       └── syn v2.0.117
│           ├── proc-macro2 v1.0.106 (*)
│           ├── quote v1.0.45 (*)
│           └── unicode-ident v1.0.24
└── zip v8.6.0
    ├── crc32fast v1.5.0 (*)
    ├── flate2 v1.1.9 (*)
    ├── indexmap v2.14.0
    │   ├── equivalent v1.0.2
    │   └── hashbrown v0.17.1
    ├── memchr v2.8.1
    └── typed-path v0.12.3
